### PR TITLE
fix(header-dropdown): mobile text is now visible

### DIFF
--- a/src/ui/Header/Header.jsx
+++ b/src/ui/Header/Header.jsx
@@ -42,10 +42,10 @@ const TopDropdownMenu = ({
     <Dropdown
       id={id}
       className={cx(className, {
-        'mobile or lower hidden': !mobileText,
+        'mobile or lower hidden': !mobileText ?? false,
         'mobile only': mobileText ?? false,
       })}
-      text={text}
+      text={mobileText || text}
       icon={icon || 'chevron down'}
       aria-label="dropdown"
     >


### PR DESCRIPTION
**mobile**: 

<img width="340" alt="Screenshot 2022-03-18 at 12 57 14 PM" src="https://user-images.githubusercontent.com/22280901/158955970-186a679d-8dff-4733-a976-d302aa9f532e.png">

**Computer** : 

<img width="1273" alt="Screenshot 2022-03-18 at 12 57 34 PM" src="https://user-images.githubusercontent.com/22280901/158956021-bc474c13-ccaf-4719-8e2a-b8001afe5a0f.png">

