### PR TITLE
Styling scroll-to-text fragments

### DIFF
--- a/theme/themes/eea/globals/reset.overrides
+++ b/theme/themes/eea/globals/reset.overrides
@@ -193,6 +193,15 @@ sup {
   top: -0.5em;
 }
 
+/**
+ * Add background and color for scroll-to-text fragments
+ */
+
+::target-text {
+  background: #e8d2fd;
+  color: #000;
+}
+
 /* Embedded content
    ========================================================================== */
 

--- a/theme/themes/eea/globals/reset.overrides
+++ b/theme/themes/eea/globals/reset.overrides
@@ -193,15 +193,6 @@ sup {
   top: -0.5em;
 }
 
-/**
- * Add background and color for scroll-to-text fragments
- */
-
-::target-text {
-  background: #e8d2fd;
-  color: #000;
-}
-
 /* Embedded content
    ========================================================================== */
 

--- a/theme/themes/eea/globals/site.overrides
+++ b/theme/themes/eea/globals/site.overrides
@@ -40,3 +40,9 @@ h2, h3, h4, h5, h6 {
 .homepage {
   color: @tertiaryColor;
 }
+
+/* Add background and color for scroll-to-text fragments */
+::target-text {
+  background: @lightLavender;
+  color: @black;
+}

--- a/theme/themes/eea/globals/site.variables
+++ b/theme/themes/eea/globals/site.variables
@@ -373,6 +373,7 @@
 @lightBlue        : #75C9DB;
 @lightViolet      : #BFC0FF;
 @lightPurple      : #DE99FF;
+@lightLavender    : #E8D2FD;
 @lightPink        : #FFBFF1;
 @lightBrown       : #D9C2AD;
 @lightGrey        : #E6E7E8;


### PR DESCRIPTION
This is the default style for text fragments that the user-agent stylesheet contains. 
See an example of highlighted text fragment: https://www.eea.europa.eu/highlights/motorised-transport-train-plane-road#:~:text=Train%20travel
We also use the same style in the search app's direct answers section to highlight the answer.
This override ensures that we use the same style across all EEA's applications.