### PR TITLE
Overide slate metadata styles

### DIFF
--- a/.project.eslintrc.js
+++ b/.project.eslintrc.js
@@ -1,15 +1,18 @@
 const fs = require('fs');
 const path = require('path');
 
-const projectRootPath = fs.realpathSync('./project');    // __dirname
+const projectRootPath = fs.existsSync('./project')
+  ? fs.realpathSync('./project')
+  : fs.realpathSync('./../../../'); // __dirname
 const packageJson = require(path.join(projectRootPath, 'package.json'));
-const jsConfig = require(path.join(projectRootPath, 'jsconfig.json')).compilerOptions;
+const jsConfig = require(path.join(projectRootPath, 'jsconfig.json'))
+  .compilerOptions;
 
 const pathsConfig = jsConfig.paths;
 
 let voltoPath = path.join(projectRootPath, 'node_modules/@plone/volto');
 
-Object.keys(pathsConfig).forEach(pkg => {
+Object.keys(pathsConfig).forEach((pkg) => {
   if (pkg === '@plone/volto') {
     voltoPath = `./${jsConfig.baseUrl}/${pathsConfig[pkg][0]}`;
   }
@@ -18,7 +21,7 @@ const AddonConfigurationRegistry = require(`${voltoPath}/addon-registry.js`);
 const reg = new AddonConfigurationRegistry(projectRootPath);
 
 // Extends ESlint configuration for adding the aliases to `src` directories in Volto addons
-const addonAliases = Object.keys(reg.packages).map(o => [
+const addonAliases = Object.keys(reg.packages).map((o) => [
   o,
   reg.packages[o].modulePath,
 ]);

--- a/theme/themes/eea/elements/list.overrides
+++ b/theme/themes/eea/elements/list.overrides
@@ -38,3 +38,9 @@ ul.ui.list li:before {
 .ui.ordered.list .list .list .list > li:before {
   margin-left: @orderedGreatGrandchildCountOffset;
 }
+
+/* override slate-metadata addon styles */
+ div.ui.list.metadata > .item .description,
+ .content {
+   margin: @itemMetadataMargin;
+ }

--- a/theme/themes/eea/elements/list.variables
+++ b/theme/themes/eea/elements/list.variables
@@ -20,6 +20,7 @@
 @itemHorizontalPadding: 0em;
 @itemPadding: @itemVerticalPadding @itemHorizontalPadding;
 @itemLineHeight: @relativeBig;
+@itemMetadataMargin: 0em;
 
 /* Sub List */
 @childListPadding: 0.25em 0em 0.25em 0.5em;

--- a/theme/themes/eea/globals/site.overrides
+++ b/theme/themes/eea/globals/site.overrides
@@ -101,3 +101,17 @@ a {
   background: @lightLavender;
   color: @black;
 }
+
+/* override slate-metadata addon styles */
+
+ .title.metadata.mention,
+ .description.metadata.mention,
+ .datetime.metadata.mention,
+ .text.metadata.mention,
+ .other_organisations.metadata.mention,
+ .preview_caption.text.metadata.mention,
+ .publisher.metadata.mention,
+ .rights.metadata.mention,
+ .topics.text.metadata.mention {
+   all: unset !important;
+ }

--- a/theme/themes/eea/modules/accordion.overrides
+++ b/theme/themes/eea/modules/accordion.overrides
@@ -142,3 +142,10 @@
 .ui.accordion.tertiary .title:not(.active):hover i {
   color: @tertiaryColorCSSVar;
 }
+
+/* override slate-metadata addon styles */
+.ui.accordion .content .ui.list.metadata > .item .content,
+.description {
+   margin: @contentListItemPadding;
+   padding: @contentListItemMargin;
+   }

--- a/theme/themes/eea/modules/accordion.variables
+++ b/theme/themes/eea/modules/accordion.variables
@@ -47,6 +47,8 @@
 @contentPadding: @squareMedium;
 @contentBackground: @grey-1;
 @contentColor: @tertiaryColor;
+@contentListItemPadding: 0em;
+@contentListItemMargin: 0em;
 
 /*-------------------
        Coupling


### PR DESCRIPTION
If you visit: https://demo-www.eea.europa.eu/en/fdgh
The slate-metadata addon, when a part of accordion child inherits the styles applied from respective overrides file. 

 
