### PR TITLE
Update components to use token values

### DIFF
--- a/theme/themes/eea/collections/breadcrumb.variables
+++ b/theme/themes/eea/collections/breadcrumb.variables
@@ -26,7 +26,7 @@
 /* Divider */
 @dividerSpacing: @5px;
 @dividerOpacity: 1;
-@dividerColor: @blue-grey-5;
+@dividerColor: @borderColorTertiaryCSSVar;
 
 @dividerSize: @relativeSmall;
 @dividerVerticalAlign: baseline;

--- a/theme/themes/eea/collections/breadcrumb.variables
+++ b/theme/themes/eea/collections/breadcrumb.variables
@@ -26,7 +26,7 @@
 /* Divider */
 @dividerSpacing: @5px;
 @dividerOpacity: 1;
-@dividerColor: @deepBlue;
+@dividerColor: @blue-grey-5;
 
 @dividerSize: @relativeSmall;
 @dividerVerticalAlign: baseline;

--- a/theme/themes/eea/collections/menu.overrides
+++ b/theme/themes/eea/collections/menu.overrides
@@ -249,7 +249,7 @@
 /*
 .ui.pagination.pointing.secondary.menu .active.item {
   padding: (@tinyGap - @1px) @tinyGap;
-  border-bottom: @secondaryPointingActiveBorderWidth solid @secondaryColor;
+  border-bottom: @secondaryPointingActiveBorderWidth solid @borderColorSecondaryCSSVar;
   margin-bottom: -@secondaryPointingctiveItemMarginBottom;
   color: @secondaryPointingActiveTextColor;
 
@@ -263,7 +263,7 @@
 /*
 .ui.pagination.pointing.secondary.menu .item:hover {
   padding: (@tinyGap - @1px) @tinyGap;
-  border-bottom: @secondaryPointingActiveBorderWidth solid @secondaryColor;
+  border-bottom: @secondaryPointingActiveBorderWidth solid @borderColorSecondaryCSSVar;
   margin-bottom: -@secondaryPointingctiveItemMarginBottom;
   color: @paginationColor;
 }
@@ -285,7 +285,7 @@
 .ui.secondary.pointing.menu:not(.vertical):not(.pagination) .item:active {
   padding: (@secondaryPointingItemVerticalPadding - @1px)
     @secondaryPointingItemHorizontalPadding;
-  border-bottom: @secondaryPointingActiveBorderWidth solid @secondaryColor;
+  border-bottom: @secondaryPointingActiveBorderWidth solid @borderColorSecondaryCSSVar;
   margin-bottom: -@secondaryPointingctiveItemMarginBottom;
   color: var(--text-color, @secondaryPointingActiveTextColor);
 }
@@ -313,7 +313,7 @@
   bottom: @1px;
   width: -moz-available;
   width: -webkit-fill-available;
-  border-top: 1px solid @grey-3;
+  border-top: 1px solid @darkBorderColor;
   content: ' ';
 }
 

--- a/theme/themes/eea/collections/menu.overrides
+++ b/theme/themes/eea/collections/menu.overrides
@@ -313,7 +313,7 @@
   bottom: @1px;
   width: -moz-available;
   width: -webkit-fill-available;
-  border-top: 1px solid @midGray;
+  border-top: 1px solid @grey-3;
   content: ' ';
 }
 

--- a/theme/themes/eea/collections/menu.variables
+++ b/theme/themes/eea/collections/menu.variables
@@ -30,7 +30,7 @@
   color @defaultDuration @defaultEasing
 ;
 @itemFontWeight: @normal;
-@itemTextColor: var(--text-color, @deepBlue);
+@itemTextColor: var(--text-color, @blue-grey-5);
 
 /* Divider */
 @dividerSize: 1px;
@@ -245,7 +245,7 @@
 /* Pointing */
 @secondaryPointingBorderWidth: @1px;
 @secondaryPointingActiveBorderWidth: @3px;
-@secondaryPointingBorderColor: @midGray;
+@secondaryPointingBorderColor: @darkBorderColor;
 @secondaryPointingItemMargin: 0 1.25rem;
 @secondaryPointingItemVerticalPadding: @tinyGap;
 @secondaryPointingItemActiveVerticalPadding: unit((@relativeTiny - @3px), rem);
@@ -269,7 +269,7 @@
 @secondaryVerticalPointingItemMargin: 0em -@secondaryPointingBorderWidth 0em 0em;
 
 
-@secondaryPointingItemBorderBottom: @1px solid @midGray;
+@secondaryPointingItemBorderBottom: @1px solid @darkBorderColor;
 @secondaryPointingItemMaxWidth: 15.625rem; 
 
 /* Inverted Secondary */
@@ -310,7 +310,7 @@
 
 /* Icon */
 @iconMenuTextAlign: center;
-@iconMenuItemColor: @grey;
+@iconMenuItemColor: @grey-4;
 @iconMenuInvertedItemColor: @white;
 
 
@@ -342,7 +342,7 @@
 /* Pagination */
 @paginationFontSize: 0.875rem;
 @paginationWidth: 100%;
-@paginationColor: @deepBlue;
+@paginationColor: @itemTextColor;
 @paginationMinWidth: 2em;
 @paginationActiveBackground: @transparentBlack;
 @paginationActiveTextColor: @selectedTextColor;

--- a/theme/themes/eea/collections/table.variables
+++ b/theme/themes/eea/collections/table.variables
@@ -36,10 +36,10 @@
 @cellHorizontalPadding: @relativeMini;
 @cellVerticalAlign: inherit;
 @cellTextAlign: center;
-@cellBorder: 1px solid @secondaryColor;
+@cellBorder: 1px solid @borderColorSecondaryCSSVar;
 
 /* Table Header */
-@headerBorder: 1px solid @secondaryColor;
+@headerBorder: 1px solid @borderColorSecondaryCSSVar;
 @headerDivider: none;
 @headerBackground: @white;
 @headerAlign: inherit;

--- a/theme/themes/eea/collections/table.variables
+++ b/theme/themes/eea/collections/table.variables
@@ -29,7 +29,7 @@
 ---------------*/
 
 /* Table Row */
-@rowBorder: 1px solid @midGray;
+@rowBorder: 1px solid @darkBorderColor;
 
 /* Table Cell */
 @cellVerticalPadding: @relativeMini;
@@ -44,7 +44,7 @@
 @headerBackground: @white;
 @headerAlign: inherit;
 @headerVerticalAlign: inherit;
-@headerColor: @deepBlue;
+@headerColor: @blue-grey-5;
 @headerVerticalPadding: @relativeSmall;
 @headerHorizontalPadding: @cellHorizontalPadding;
 @headerFontStyle: none;

--- a/theme/themes/eea/elements/button.overrides
+++ b/theme/themes/eea/elements/button.overrides
@@ -132,7 +132,7 @@ p.ui.button {
 /* Advanced Search Button - to be deleted*/
 .ui.button.search {
   box-sizing: border-box;
-  border: @buttonBorder @white;
+  border: @buttonBorder @whiteBorderColor;
   background: @searchButtonBackground;
   border-radius: @searchButtonBorderRadius;
   color: @searchButtonColor;
@@ -142,7 +142,7 @@ p.ui.button {
   &:visited,
   &:focus,
   &:hover {
-    border: @buttonBorder @white;
+    border: @buttonBorder @whiteBorderColor;
     background: @searchButtonBackground;
     color: @searchButtonColor;
   }
@@ -185,7 +185,7 @@ p.ui.button {
 /* Primary - button.less - L:3128 */
 .ui.inverted.primary.buttons .button,
 .ui.inverted.primary.button {
-  box-shadow: 0px 0px 0px @invertedBorderSize @primaryColor inset !important;
+  box-shadow: 0px 0px 0px @invertedBorderSize @borderColorPrimaryCSSVar inset !important;
   color: @primaryColor;
 }
 
@@ -223,7 +223,7 @@ p.ui.button {
 /* Secondary - button.less - L:3128 */
 .ui.inverted.secondary.buttons .button,
 .ui.inverted.secondary.button {
-  box-shadow: 0px 0px 0px @invertedBorderSize @secondaryColor inset !important;
+  box-shadow: 0px 0px 0px @invertedBorderSize @borderColorSecondaryCSSVar inset !important;
   color: @secondaryColor;
 }
 

--- a/theme/themes/eea/elements/button.variables
+++ b/theme/themes/eea/elements/button.variables
@@ -6,35 +6,9 @@
        Element
 --------------------*/
 
-
-
 /* Button */
 @buttonBorder: @relative2px solid;
 @buttonDisabledOpacity: 1;
-
-/* Primary Button */
-@primaryButtonColor: @primaryColor;
-@primaryButtonColorHover: @darkMidnightBlue;
-@primaryButtonBackgroundActive: @mediumPersianBlue;
-@primaryButtonDisabledBackground: @midBlue;
-
-/* Secondary Button */
-@secondaryButtonBackground: transparent;
-@secondaryButtonColor: @darkMidnightBlue;
-@secondaryButtonColorHover : @white;
-@secondaryBorder: @buttonBorder @darkMidnightBlue;
-@secondaryBorderHover: @buttonBorder @darkMidnightBlue;
-@secondaryButtonDisabledColor: @weldonBlue;
-
-/* Secondary Button Inverted */
-@secondaryButtonInvertedColor: @white;
-@secondaryButtonInvertedColorHover: @darkMidnightBlue;
-
-/* Action Button */
-@actionButtonColor: @white;
-@actionButtonBackground: @darkCyan;
-@actionButtonBackgroundHover: #2E6173;
-@actionButtonBackgroundActive: @pineGreen;
 
 /* Text Button */
 @textButtonBackground: transparent;
@@ -50,7 +24,7 @@
 
 @verticalMargin: 0.25em;
 @horizontalMargin: 0.25em;
-@backgroundColor: @silverGray;
+@backgroundColor: @grey-2;
 @backgroundImage: none;
 @background: @backgroundColor @backgroundImage;
 @lineHeight: 1em;
@@ -126,7 +100,7 @@
 --------------------*/
 
 /* Hovered */
-@hoverBackgroundColor: @midGray;
+@hoverBackgroundColor: @grey-3;
 @hoverBackgroundImage: @backgroundImage;
 @hoverBoxShadow: @boxShadow;
 @hoverColor: @hoveredTextColor;

--- a/theme/themes/eea/elements/divider.variables
+++ b/theme/themes/eea/elements/divider.variables
@@ -57,6 +57,6 @@
 @shortMarginInline: auto;
 
 /* Color */
-@dividerPrimary   : @primaryColor;
-@dividerSecondary : @secondaryColor;
-@dividerTertiary  : @tertiaryColor;
+@dividerPrimary   : @borderColorPrimaryCSSVar;
+@dividerSecondary : @borderColorSecondaryCSSVar;
+@dividerTertiary  : @borderColorTertiaryCSSVar;

--- a/theme/themes/eea/elements/input.variables
+++ b/theme/themes/eea/elements/input.variables
@@ -21,7 +21,7 @@
 @textAlign: left;
 @background: @inputBackground;
 @borderWidth: 1px;
-@border: @borderWidth solid @midGray;
+@border: @borderWidth solid @darkBorderColor;
 @boxShadow: none;
 
 @borderRadius: @defaultBorderRadius;

--- a/theme/themes/eea/elements/label.variables
+++ b/theme/themes/eea/elements/label.variables
@@ -248,7 +248,7 @@
 @emptyCircleSize: 0.5em;
 
 /* Pointing */
-@pointingBorderColor: @grey-4;
+@pointingBorderColor: @backgroundColor;
 @pointingBorderWidth: 0;
 @pointingVerticalDistance: 1em;
 @pointingTriangleSize: 0.6666em;

--- a/theme/themes/eea/elements/label.variables
+++ b/theme/themes/eea/elements/label.variables
@@ -11,7 +11,7 @@
 @verticalAlign: baseline;
 @verticalMargin: 0;
 @horizontalMargin: 0;
-@backgroundColor: @grey;
+@backgroundColor: @grey-4;
 @color: @white;
 @backgroundImage: none;
 @verticalPadding: 0.5833em; /* medium is not @emSize custom value required */
@@ -248,7 +248,7 @@
 @emptyCircleSize: 0.5em;
 
 /* Pointing */
-@pointingBorderColor: @grey;
+@pointingBorderColor: @grey-4;
 @pointingBorderWidth: 0;
 @pointingVerticalDistance: 1em;
 @pointingTriangleSize: 0.6666em;

--- a/theme/themes/eea/elements/label.variables
+++ b/theme/themes/eea/elements/label.variables
@@ -153,20 +153,20 @@
 
 /* Colors */
 @globalLabelColor: @white;
-@lowImportanceBackground: @deepBlue;
+@lowImportanceBackground: @blue-grey-5;
 @mediumImportanceBackground: #346F83;
 @highImportanceBackground: #005293;
 @highlightImportanceBackground: @secondaryColor;
 
 /* Hover Colors */
-@lowImportanceHoverBackground: darken(@deepBlue,5);
+@lowImportanceHoverBackground: darken(@blue-grey-5,5);
 @mediumImportanceHoverBackground: darken(#346F83,5);
 @highImportanceHoverBackground: darken(#005293,5);
 @highlightImportanceHoverBackground: darken(@secondaryColor,5);
 
 @importanceHoverTextColor: @white;
 
-@lowImportanceBasicTextColor: @deepBlue;
+@lowImportanceBasicTextColor: @blue-grey-5;
 @mediumImportanceBasicTextColor: #346F83;
 @highImportanceBasicTextColor: #005293;
 @highlightImportanceBasicTextColor: @secondaryColor;

--- a/theme/themes/eea/elements/segment.overrides
+++ b/theme/themes/eea/elements/segment.overrides
@@ -53,7 +53,7 @@
 }
 
 .ui.segment.dashed {
-  border: 3px dashed #ccc;
+  border: 3px dashed @borderColor;
   box-shadow: none;
 }
 

--- a/theme/themes/eea/extras/banner.variables
+++ b/theme/themes/eea/extras/banner.variables
@@ -86,5 +86,5 @@
 @sharePopupFontWeight: 500;
 @sharePopupLineHeight: 1rem;
 // Actions
-@sharePopupActionsIconColor: @pineGreen;
+@sharePopupActionsIconColor: @secondaryColor;
 @sharePopupActionsIconMargin: 0;

--- a/theme/themes/eea/extras/contextNavigation.variables
+++ b/theme/themes/eea/extras/contextNavigation.variables
@@ -15,7 +15,7 @@
 @sidenavHeaderFontSize: @font-size-3;
 @sidenavHeaderFontWeight: @font-weight-7;
 @sidenavHeaderPadding: @rem-space-4;
-@sidenavHeaderBorderBottom: @2px solid @blue-grey-5;
+@sidenavHeaderBorderBottom: @2px solid @borderColorTertiaryCSSVar;
 @sidenavHeaderIconMarginRight: @rem-space-4;
 
 /* Header icon */
@@ -24,7 +24,7 @@
 @sidenavHeaderIconPaddingRight: @rem-space-4;
 
 /* Content */
-@sidenavContentBorderBottom: 1px solid @tertiaryColor;
+@sidenavContentBorderBottom: 1px solid @borderColorTertiaryCSSVar;
 
 /* Nav item */
 @sidenavItemPadding: @rem-space-2 0 @rem-space-2 @rem-space-8;

--- a/theme/themes/eea/extras/custom.overrides
+++ b/theme/themes/eea/extras/custom.overrides
@@ -138,7 +138,7 @@
 .tabs-block {
   .border-left {
     border-right: none !important;
-    border-left: 0.0625rem solid @midGray !important;
+    border-left: 0.0625rem solid @darkBorderColor !important;
 
     .item.active {
       border-right: none !important;
@@ -153,7 +153,7 @@
 
   .border-top {
     border: none !important;
-    border-top: 0.0625rem solid @midGray !important;
+    border-top: 0.0625rem solid @darkBorderColor !important;
 
     &::before {
       border-top: none !important;

--- a/theme/themes/eea/extras/downloadLabeledIcon.variables
+++ b/theme/themes/eea/extras/downloadLabeledIcon.variables
@@ -10,7 +10,7 @@
 /* Label */
 @downloadLabeledIconLabelWidth: 100%;
 @downloadLabeledIconLabelFontSize: 0.875rem;
-@downloadLabeledIconLabelColor: @deepBlue;
+@downloadLabeledIconLabelColor: @blue-grey-5;
 
 /* Wrapper */
 @downloadLabeledIconWrapperWidth: 100%;
@@ -20,7 +20,7 @@
 @downloadLabeledIconIconFontSize: 1.563rem;
 @downloadLabeledIconWrapperIconHeight: 1.25rem;
 @downloadLabeledIconIconWidth: 1.25rem;
-@downloadLabeledIconColor: @mediumPersianBlue;
+@downloadLabeledIconColor: @blue-4;
 
 /* Link Wrapper */
 @downloadLabeledIconLinkWrapperBackgroundColor: #f9f9f9;
@@ -33,7 +33,7 @@
 /* List */
 @downloadLabeledIconUlMargin: 0.25rem 0;
 @downloadLabeledIconUlPaddingInlineStart: 0.25rem 0px;
-@downloadLabeledIconLiHover: @japaneseIndigo;
+@downloadLabeledIconLiHover: @blue-grey-6;
 
 /* Link */
 @downloadLabeledIconALinkFontWeight: 700;
@@ -41,5 +41,5 @@
 @downloadLabeledIconLinkIconFontSize: 1rem;
 @downloadLabeledIconLinkIconPadding: 0.125rem 0.875rem;
 @downloadLabeledIconLinkIconLineHeight: 1.25rem;
-@downloadLabeledIconALinkColor: @japaneseIndigo;
+@downloadLabeledIconALinkColor: @blue-grey-6;
 @downloadLabeledIconALinkColorHover: @white;

--- a/theme/themes/eea/extras/header.variables
+++ b/theme/themes/eea/extras/header.variables
@@ -124,7 +124,7 @@
 @mainMenuItemPadding                  : @rem-space-050 @rem-space-2;
 @mainMenuItemActiveColor              : @secondaryColor;
 @mainMenuItemBorder                   : 4px solid transparent;
-@mainMenuItemActiveBorder             : 4px solid @secondaryColor;
+@mainMenuItemActiveBorder             : 4px solid @borderColorSecondaryCSSVar;
 @mainMenuInvertedItemActiveBorder     : 4px solid @white;
 @mainMenuItemAlignSelf                : flex-end;
 
@@ -182,7 +182,7 @@
 @megaMenuListItemFontSize: @font-size-1;
 @megaMenuListItemFontWeight: @font-weight-4;
 @megaMenuListItemPadding: @rem-space-2 0;
-@megaMenuListItemActiveBorder: 4px solid #FFF;
+@megaMenuListItemActiveBorder: 4px solid @white;
 @megaMenuListItemActivePadding: 8px;
 
 /* Topics */

--- a/theme/themes/eea/extras/header.variables
+++ b/theme/themes/eea/extras/header.variables
@@ -139,7 +139,7 @@
 @subsiteDividerHeight                 : 110%;
 @subsiteDividerWidth                  : 1px;
 @subsiteDividerTopPosition            : 50%;
-@subsiteDividerColor                  : @darkCyan;
+@subsiteDividerColor                  : @secondaryColor;
 @mobileSubsiteFontSize                : unit(@h6, em);
 @tabletSubsiteFontSize                : unit(@h4, em);
 @computerSubsiteFontSize              : unit(@h2, em);
@@ -152,7 +152,7 @@
 @mobileActionsBoxWidth: 44px;
 @tabletActionsBoxWidth: 66px;
 @computerActionsBoxWidth: 72px;
-@burgerActionBackgroundColor: @darkMidnightBlue;
+@burgerActionBackgroundColor: @blue-6;
 
 /* Mega menu and Search popup */
 @mobilePopupMarginTop   : 5vh;
@@ -161,7 +161,7 @@
 
 /* Mega menu */
 @mobileMegaMenuWidth: 94%;
-@megaMenuBackgroundColor: @darkMidnightBlue;
+@megaMenuBackgroundColor: @blue-6;
 @megaMenuTextDisplay: flex;
 @megaMenuTextColor: @white;
 @megaMenuTextHoverDecoration: underline;

--- a/theme/themes/eea/extras/inpageNavigation.variables
+++ b/theme/themes/eea/extras/inpageNavigation.variables
@@ -4,7 +4,7 @@
 
 @navBottom            : @largeGap;
 @navRight             : @largeGap;
-@navBackground        : @darkCerulean;
+@navBackground        : @primaryColor;
 @navColor             : @white;
 @navFontWeight        : @bold;
 

--- a/theme/themes/eea/extras/keyContent.variables
+++ b/theme/themes/eea/extras/keyContent.variables
@@ -9,7 +9,7 @@
 @keyContentListGap:  @largeGap;
 
 /* Item */
-@keyContentItemColor : @japaneseIndigo;
+@keyContentItemColor : @blue-grey-6;
 @mobileKeyContentItemFontSize : 1rem;
 @computerKeyContentItemFontSize: 1.25rem;
 @keyContentItemMarginLeft : @hugeGap;
@@ -20,5 +20,5 @@
 @keyContentListBulletFontSize : 3rem;
 
 /* Colored Title */
-@keyContentColoredTitleColor : @darkCyan;
+@keyContentColoredTitleColor : @secondaryColor;
 @keyContentTitleMarginLeft : 2.8rem;

--- a/theme/themes/eea/extras/languageLabeledIcon.variables
+++ b/theme/themes/eea/extras/languageLabeledIcon.variables
@@ -10,15 +10,15 @@
 /* Icon Wrapper  */
 @languageLabeledIconIconWrapperFontSize : 0.875rem;
 @languageLabeledIconIconWrapperFontWeight : 400;
-@languageLabeledIconIconWrapperColor : @deepBlue;
+@languageLabeledIconIconWrapperColor : @blue-grey-5;
 
 /* Icon  */
-@languageLabeledIconIconWrapperIconColor: @mediumPersianBlue;
+@languageLabeledIconIconWrapperIconColor: @blue-4;
 @languageLabeledIconIconWrapperIconMarginRight: 0.25rem;
 @languageLabeledIconIconWrapperIconFontSize: 1.5rem;
 
 /* Label  */
-@languageLabeledIconLabelColor: @deepBlue;
+@languageLabeledIconLabelColor: @blue-grey-5;
 @languageLabeledIconLabelFontSize: 0.875rem;
 @languageLabeledIconLabelFontWeight: 400;
 
@@ -31,11 +31,11 @@
 
 /* List  */
 @languageLabeledIconLabelUlMargin:0;
-@languageLabeledIconLabelUlColor: @japaneseIndigo;
+@languageLabeledIconLabelUlColor: @blue-grey-6;
 @languageLabeledIconLabelUlPadding: 0.25rem;
 
 /* List Item  */
 @languageLabeledIconLabelUlLiPadding: 0.125rem 0.313rem;
 @languageLabeledIconLabelUlLiColor: @white;
-@languageLabeledIconLabelUlLiBackgroundColor: @japaneseIndigo;
+@languageLabeledIconLabelUlLiBackgroundColor: @blue-grey-6;
 @languageLabeledIconLabelUlLiSpanFontWeight: 700;

--- a/theme/themes/eea/extras/main.variables
+++ b/theme/themes/eea/extras/main.variables
@@ -22,8 +22,8 @@
 @mobileMenuNavItemLineHeight: 1.25;
 
 /* Checkbox */
-@checkboxBorderUnchecked: 1px solid @oldSilver;
-@checkboxBorderChecked: 1px solid @darkCerulean;
+@checkboxBorderUnchecked: 1px solid @grey-4;
+@checkboxBorderChecked: 1px solid @blue-5;
 @checkboxColor: @white;
 @checkboxBoxShadow: none;
 

--- a/theme/themes/eea/extras/newTabLabeledIcon.variables
+++ b/theme/themes/eea/extras/newTabLabeledIcon.variables
@@ -10,8 +10,8 @@
 /* Label */
 @newTabLabeledIconLabelWidth: 100%;
 @newTabLabeledIconLabelFontSize: 0.875rem;
-@newTabLabeledIconLabelColor: @deepBlue;
-@newTabLabeledIconColor: @mediumPersianBlue;
+@newTabLabeledIconLabelColor: @blue-grey-5;
+@newTabLabeledIconColor: @blue-4;
 
 /* Icon Wrapper */
 @newTabLabeledIconIconWrapperWidth: 100%;

--- a/theme/themes/eea/extras/testimonial.variables
+++ b/theme/themes/eea/extras/testimonial.variables
@@ -14,7 +14,7 @@
 @mobileTestimonialContentTitleMarginHorizontal : 0;
 @tabletTestimonialContentTitleMarginHorizontal : 3.125rem;
 @testimonialContentTitleFontWeight             : 500;
-@testimonialContentTitleColor                  : @deepBlue;
+@testimonialContentTitleColor                  : @blue-grey-5;
 
 /* Image */
 @mobileCardImageWidth  : 100px;

--- a/theme/themes/eea/extras/timeline.variables
+++ b/theme/themes/eea/extras/timeline.variables
@@ -23,12 +23,12 @@
 @timelineLabelFontSize     : 0.875rem;
 
 /* Line */
-@timelineLineBorderLeft    : @2px solid @silverGray;
+@timelineLineBorderLeft    : @2px solid @borderColor;
 
 /* Colors */
 @timelineBlue   : @blue;
 @timelineGreen  : @green;
-@timelineGrey   : @midGray;
+@timelineGrey   : @grey-3;
 @timelineRed    : @red;
 @timelineOrange : @orange;
 @timelineYellow : @yellow;

--- a/theme/themes/eea/globals/site.variables
+++ b/theme/themes/eea/globals/site.variables
@@ -55,20 +55,20 @@
     Brand Colors
 --------------------*/
 
-@primaryColor         : @darkCerulean;
+@primaryColor         : @blue-5;
 @primaryColorCSSVar   : var(--text-color-primary, @primaryColor);
-@secondaryColor       : @pineGreen;
+@secondaryColor       : @green-5;
 @secondaryColorCSSVar : var(--text-color-secondary, @secondaryColor);
-@tertiaryColor        : @deepBlue;
+@tertiaryColor        : @blue-grey-5;
 @tertiaryColorCSSVar  : var(--text-color-tertiary, @tertiaryColor);
 
-@lightPrimaryColor    : @mediumPersianBlue;
-@lightSecondaryColor  : @darkCyan;
-@lightTertiaryColor   : @UCLABlue;
+@lightPrimaryColor    : @blue-4;
+@lightSecondaryColor  : @green-4;
+@lightTertiaryColor   : @blue-grey-4;
 
-@darkPrimaryColor     : @darkMidnightBlue;
-@darkSecondaryColor   : @bottleGreen;
-@darkTertiaryColor    : @japaneseIndigo;
+@darkPrimaryColor     : @blue-6;
+@darkSecondaryColor   : @green-6;
+@darkTertiaryColor    : @blue-grey-6;
 
 /*--------------
   Page Heading
@@ -336,44 +336,13 @@
       Site Colors
 --------------------*/
 
-/*---  EEA Colors  ---*/
-
-// Green Colors - Darker to lighter
-@bottleGreen      : #00665A;
-@pineGreen        : #007B6C;
-@darkCyan         : #00928F;
-@pearlAqua        : #74CBC8;
-@powderBlue       : #AEDFE8;
-
-// Blue Colors - Darker to lighter
-@darkMidnightBlue   : #0A3D61;
-@darkCerulean       : #004B7F;
-@mediumPersianBlue  : #0065A4;
-@steelBlue          : #478EA5;
-@midBlue            : #75C9DB;
-
-// Secondary Colors - Darker to lighter
-@japaneseIndigo   : #2E3E4C;
-@deepBlue         : #3D5265;
-@UCLABlue         : #54728C;
-@weldonBlue       : #7495B2;
-@lightSteelBlue   : #ACCAE5;
-
-//Gray Colors
-@black            : #000000;
-@oldSilver        : #808285;
-@midGray          : #BCBEC0;
-@silverGray       : #E6E7E8;
-@white            : #FFFFFF;
-
-
 /*---  Colors  ---*/
 @orange           : #FF9933;
 @yellow           : #F2EB49;
 @olive            : #78AB66;
-@green            : @pineGreen;
+@green            : @green-5;
 @teal             : #00928F;
-@blue             : @darkCerulean;
+@blue             : @blue-5;
 @violet           : #6667AB;
 @purple           : #A530B8;
 @pink             : #F255D0;
@@ -464,12 +433,12 @@
 @sidebarToggleButtonHighlightColor: @grey;
 
 /*--- Progress Colors ---*/
-@progressBarFrom0to30    : @midBlue;
-@progressBarFrom30to40   : @mediumPersianBlue;
-@progressBarFrom40to60   : @mediumPersianBlue;
-@progressBarFrom60to70   : @pineGreen;
-@progressBarFrom70to90   : @pineGreen;
-@progressBarFrom90to100  : @bottleGreen;
+@progressBarFrom0to30    : @blue-0;
+@progressBarFrom30to40   : @blue-4;
+@progressBarFrom40to60   : @blue-4;
+@progressBarFrom60to70   : @green-5;
+@progressBarFrom70to90   : @green-5;
+@progressBarFrom90to100  : @green-6;
 
 /*-------------------
      Alpha Colors
@@ -642,7 +611,9 @@
 
 @circularRadius                : 50%;
 
-@borderColor               : @silverGray;
+@borderColor               : @grey-2;
+@lightBorderColor          : var(--light-border-color, @grey-1);
+@darkBorderColor           : var(--dark-border-color, @grey-3);
 @strongBorderColor         : rgba(34, 36, 38, 0.22);
 @internalBorderColor       : rgba(34, 36, 38, 0.1);
 @selectedBorderColor       : rgba(34, 36, 38, 0.35);

--- a/theme/themes/eea/modules/accordion.variables
+++ b/theme/themes/eea/modules/accordion.variables
@@ -11,12 +11,12 @@
 @titlePadding: @rectangleMedium;
 @titleFontSize: 1.125rem;
 @titleColor: @textColorCSSVar;
-@titleBorderBottom: @1px solid @silverGray;
+@titleBorderBottom: @1px solid @grey-2;
 @titleColorHover:var(--text-color-hover, @grey-5);
 @titleJustifyContent: space-between;
 
 /* Icon */
-@iconColor: var(--text-color, @oldSilver);
+@iconColor: var(--text-color, @grey-4);
 @iconColorActive: @white;
 @iconOpacity: 1;
 @iconFontSize: 3rem;

--- a/theme/themes/eea/modules/accordion.variables
+++ b/theme/themes/eea/modules/accordion.variables
@@ -11,7 +11,7 @@
 @titlePadding: @rectangleMedium;
 @titleFontSize: 1.125rem;
 @titleColor: @textColorCSSVar;
-@titleBorderBottom: @1px solid @grey-2;
+@titleBorderBottom: @1px solid @borderColor;
 @titleColorHover:var(--text-color-hover, @grey-5);
 @titleJustifyContent: space-between;
 

--- a/theme/themes/eea/modules/dropdown.variables
+++ b/theme/themes/eea/modules/dropdown.variables
@@ -16,7 +16,7 @@
 ;
 @borderRadius: @defaultBorderRadius;
 @borderWidth: @1px;
-@border: @borderWidth solid @midGray;
+@border: @borderWidth solid @darkBorderColor;
 
 @raisedShadow: 0px 2px 3px 0px @borderColor;
 

--- a/theme/themes/eea/modules/popup.variables
+++ b/theme/themes/eea/modules/popup.variables
@@ -147,7 +147,7 @@
 
 /* Colors */
 @globalLabelColor: @white;
-@lowImportanceBackground: @deepBlue;
+@lowImportanceBackground: @blue-grey-5;
 @mediumImportanceBackground: #346F83;
 @highImportanceBackground: #005293;
 @highlightImportanceBackground: #009591;

--- a/theme/themes/eea/views/card.variables
+++ b/theme/themes/eea/views/card.variables
@@ -6,7 +6,7 @@
          View
 --------------------*/
 
-@cardBorder: 1px solid @midGray;
+@cardBorder: 1px solid @darkBorderColor;
 @cardColor: @tertiaryColor;
 @background: @white;
 
@@ -116,8 +116,8 @@
 @headerLinkColor: @headerColor;
 @headerLinkHoverColor: @linkHoverColor;
 
-@metaLinkColor: @deepBlue;
-@metaLinkHoverColor: @deepBlue;
+@metaLinkColor: @linkColor;
+@metaLinkHoverColor: @linkHoverColor;
 
 /* Description */
 @descriptionDistance: 0;
@@ -343,9 +343,9 @@
 @carouselDotsFontSize: 0.75rem;
 @carouselDotsBorderRadius: 50%;
 @carouselDotsOpacity: 1;
-@carouselDotsBorder: 1px solid @darkCerulean;
+@carouselDotsBorder: 1px solid @primaryColor;
 @carouselDotsBackgroundColor: @white;
-@carouselDotsActiveBackgroundColor: @darkCerulean;
+@carouselDotsActiveBackgroundColor: @primaryColor;
 @mobileCarouselDotsWidth: 0.875rem;
 @mobileCarouselDotsHeight: 0.875rem;
 

--- a/theme/themes/eea/views/item.variables
+++ b/theme/themes/eea/views/item.variables
@@ -184,7 +184,7 @@
 @tabletDefaultItemWidth: 35%;
 
 @defaultItemBackgroundColor: @white;
-@defaultItemColor: @deepBlue;
+@defaultItemColor: @blue-grey-5;
 
 /* Extra */
 @mobileDefaultItemExtraMarginBottom: 1.5rem;


### PR DESCRIPTION
https://taskman.eionet.europa.eu/issues/160247

All the border colors that had hex number or a color token are replaced.
https://62713c57bcbdf4004a3d99b8-ubqdlqnylz.chromatic.com/

Some things to discuss before merging to finalize borders:
- There are still a lot of semantic border color tokens in site.variables, if we want them removed now is the time (@strongBorderColor, @internalBorderColor, etc.). Some of them are used a lot in the code, mostly for things that we didn't need to override (@solidBorderColor) so deleting them all might be time consuming.
- Many components have custom rbga colors assign to their own border color tokens. (input.variables, button box shadows, etc.) If we need them gone, I should create a full list and ask the ux team.
- We have to create a **white** variable or override the (@**whiteBorderColor**: rgba(255, 255, 255, 0.1); We have white borders in the design (header menu items).
- For the checkbox border (main.variables in extras) the design team prefers if we don't assign the primary border color token, I left them as they were for now for you to check

PS: Latest commit: **_refactor(Borders): Update segment and label_** is separated because I took the liberty to assign the background color of the **label** to the border and changed the semantic dash border of the **segment** to a bit different token