### PR TITLE
fix: Refs#255840 - hover and focused border for block child

### DIFF
--- a/theme/themes/eea/extras/main.overrides
+++ b/theme/themes/eea/extras/main.overrides
@@ -38,3 +38,9 @@
 #main main {
   overflow: inherit;
 }
+
+// with z-index: -1 you don't get the hover and focused border for block child section
+// TODO: to be removed if https://github.com/plone/volto/pull/5029 merged
+.block .block:not(.inner)::before {
+  z-index: auto;
+}


### PR DESCRIPTION
Fix hover and focused border for block child.
