### PR TITLE
fix: fix teaser-grid covering block remove #256275

### DIFF
--- a/theme/themes/eea/extras/custom.overrides
+++ b/theme/themes/eea/extras/custom.overrides
@@ -127,6 +127,10 @@
   color: inherit;
 }
 
+.block-editor-__grid .block .toolbar, [class$='Grid'] .block .toolbar {
+  top: 0px;
+}
+
 // Tabs block border left/top
 .tabs-block {
   .border-left {

--- a/theme/themes/eea/extras/custom.overrides
+++ b/theme/themes/eea/extras/custom.overrides
@@ -127,7 +127,7 @@
   color: inherit;
 }
 
-.block-editor-__grid .block .toolbar, [class$='Grid'] .block .toolbar {
+.quanta-block-toolbar .teaserGrid .teaserGrid .block-editor-__grid .block .toolbar, [class$='Grid'] .block .toolbar {
   top: 0px;
 }
 

--- a/theme/themes/eea/extras/custom.overrides
+++ b/theme/themes/eea/extras/custom.overrides
@@ -127,7 +127,7 @@
   color: inherit;
 }
 
-.quanta-block-toolbar .teaserGrid .teaserGrid .block-editor-__grid .block .toolbar, [class$='Grid'] .block .toolbar {
+.quanta-block-toolbar .teaserGrid .block .toolbar {
   top: 0px;
 }
 

--- a/theme/themes/eea/extras/custom.overrides
+++ b/theme/themes/eea/extras/custom.overrides
@@ -127,8 +127,9 @@
   color: inherit;
 }
 
-.quanta-block-toolbar .teaserGrid .block .toolbar {
+.quanta-block-editor-teaserGrid .teaserGrid .toolbar {
   top: 0px;
+  margin: 5px;
 }
 
 // Tabs block border left/top


### PR DESCRIPTION
kitconcept Teaser-grid issue with quanta toolbar 

![Screenshot from 2023-08-08 17-36-55](https://github.com/eea/volto-eea-design-system/assets/44702393/e7bde31a-f3fa-43b3-9c7a-5844b53e1dfa)


Teaser-grid block toolbar is covering the volto block "delete block"

![can_remove_listing_block](https://github.com/eea/volto-eea-design-system/assets/44702393/521fb89b-d5b0-4867-85c3-1b074dd506a0)
