### PR TITLE
Fix accordion if statement for icon className

### DIFF
--- a/src/ui/Accordion/Accordion.stories.js
+++ b/src/ui/Accordion/Accordion.stories.js
@@ -106,7 +106,7 @@ function AccordionContainer({ ...args }) {
                   <span>{panel.title}</span>
                   <Icon
                     className={
-                      active ? 'ri-arrow-down-s-line' : 'ri-arrow-up-s-line'
+                      active ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line'
                     }
                   />
                 </Accordion.Title>


### PR DESCRIPTION
Minor fix for the accordion icons. They are reversed in production.
https://eea.github.io/eea-storybook/?path=/story/components-accordion--default

https://62713c57bcbdf4004a3d99b8-jmmyikdqlr.chromatic.com/?path=/story/components-accordion--default