### PR TITLE
Refs #263347 - Tags and topics are not recognizable as links

### DIFF
--- a/theme/themes/eea/globals/site.overrides
+++ b/theme/themes/eea/globals/site.overrides
@@ -220,3 +220,10 @@ a {
     page-break-inside: auto;
   }
 }
+
+.block.metadata.subjects.token.widget.tags-content .tag .name,
+.block.metadata.subjects.token.widget.tags-content i.hashtag.icon.icon,
+.block.metadata.topics.token.widget.tags-content .tag .name,
+.block.metadata.topics.token.widget.tags-content i.hashtag.icon.icon {
+  color: var(--text-color, #006bb8);
+}


### PR DESCRIPTION
This change would make it more clear to the visitors that those tags are links instead of just a listing of some names
that get the same color as the body text.